### PR TITLE
Remove parser dependency in image module

### DIFF
--- a/schedule_bot/convert_text_to_image.py
+++ b/schedule_bot/convert_text_to_image.py
@@ -1,10 +1,7 @@
 """Файл для создания изображений с расписанием."""
 
 import datetime
-from typing import List
 from PIL import Image, ImageDraw, ImageFont
-import pdf_parser
-import xls_parser
 import os
 import glob
 
@@ -19,20 +16,13 @@ async def del_img(school):
         os.remove(img)
 
 
-async def get_schedules(school: str) -> List:
-    if school == "14":
-        return await pdf_parser.get_classes_schedules()
-    elif school == "40":
-        return await xls_parser.get_classes_schedules()
-
-
-async def make_image(date, school):
+async def make_image(schedules, date, school):
     """Фунция для создания изображения с расписанием."""
     await del_img(school)
     list_10_11 = []
     date_first_number = await get_date(date)
     next_date = await get_next_date(date)
-    for class_ in await get_schedules(school):
+    for class_ in schedules:
         class_name = class_.class_name
         list_schedule = class_.schedule
         bells = class_.bells

--- a/schedule_bot/schedule_parser14.py
+++ b/schedule_bot/schedule_parser14.py
@@ -11,6 +11,8 @@ import os
 import aiohttp
 import aiofiles
 
+import pdf_parser
+
 URL = "https://s11018.edu35.ru/obuchayushchimsya/raspisanie-urokov"
 HEADERS = {
     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36",
@@ -100,7 +102,8 @@ async def parse14(bot):
                 await get_link_and_filename(html)
             )
             if bool_meaning:
-                await make_image(filename.split(), "14")
+                schedules = await pdf_parser.get_classes_schedules()
+                await make_image(schedules, filename.split(), "14")
                 if status == "Update":
                     for user_id in await get_users_id("14"):
                         try:

--- a/schedule_bot/schedule_parser40.py
+++ b/schedule_bot/schedule_parser40.py
@@ -11,6 +11,8 @@ from vkbottle import CodeException
 from db_users import get_users_id, unsubscribe_on_newsletter
 from convert_text_to_image import make_image
 
+import xls_parser
+
 
 URL = "https://s11028.edu35.ru/2013-06-12-15-17-31/raspisanie"
 HEADERS = {
@@ -132,7 +134,8 @@ async def parse40(bot) -> None:
                 await get_link_and_filename(code)
             )
             if bool_meaning:
-                await make_image(date.split(), "40")
+                schedules = await xls_parser.get_classes_schedules()
+                await make_image(schedules, date.split(), "40")
                 if status == "Update":
                     for user_id in await get_users_id("40"):
                         try:


### PR DESCRIPTION
Рендеринг расписания не должен зависеть от парсеров. В идеале модуль должен состоять из (названия субъективные):

- ... одной функции:

~~~python
def render_schedule(schedule: ClassSchedule) -> PIL.Image
~~~

- ... или одного метода:

~~~python
class ClassSchedule:
    ...
    def render(self) -> PIL.Image
~~~

Всё, что относится к получению нового расписания, удалению старого, сохранению файла, должно быть вне функции/метода. В этом ПР я убрал только один [side effect](https://www.youtube.com/watch?v=KSJVDqk5X0Q) (самый простой). Избавление от оставшихся side effect'ов доверяю автору проекта.